### PR TITLE
Added more entity editing options

### DIFF
--- a/__tests__/store.test.ts
+++ b/__tests__/store.test.ts
@@ -204,6 +204,37 @@ describe('Store', function () {
           },
         ]
       `);
+
+      store.dispatch(
+        entityActions.removeReference({
+          id: 'https://example.org/manifest-1',
+          type: 'Manifest',
+          key: 'items',
+          reference: {
+            id: 'https://example.org/manifest-1/canvas-2',
+            type: 'Canvas',
+          },
+          index: 3, // <-- THIS IS THE INCORRECT INDEX, CANVAS 2 IS AT INDEX 2
+        })
+      );
+      expect(store.getState().iiif.entities.Manifest['https://example.org/manifest-1'].items).toHaveLength(3);
+
+      store.dispatch(
+        entityActions.removeReference({
+          id: 'https://example.org/manifest-1',
+          type: 'Manifest',
+          key: 'items',
+          reference: {
+            id: 'https://example.org/manifest-1/canvas-2',
+            type: 'Canvas',
+          },
+          index: 2, // <-- THIS IS THE CORRECT INDEX
+        })
+      );
+      expect(store.getState().iiif.entities.Manifest['https://example.org/manifest-1'].items).toHaveLength(2);
+
+
+
     });
   });
 });

--- a/__tests__/store.test.ts
+++ b/__tests__/store.test.ts
@@ -1,0 +1,209 @@
+import { createStore } from '../src/store';
+import { entityActions } from '../src/actions';
+import { emptyCanvas, emptyManifest } from '@iiif/parser';
+
+describe('Store', function () {
+  test('It should be creatable', () => {
+    const store = createStore();
+
+    expect(store).toBeDefined();
+  });
+
+  describe('Entity actions', () => {
+    test('Import entity', () => {
+      const store = createStore();
+
+      store.dispatch(
+        entityActions.importEntities({
+          entities: {
+            Manifest: {
+              'https://example.org/manifest-1': {
+                ...emptyManifest,
+                id: 'https://example.org/manifest-1',
+                type: 'Manifest',
+                items: [],
+              },
+            },
+          },
+        })
+      );
+
+      expect(store.getState().iiif.entities.Manifest['https://example.org/manifest-1'].id).toEqual(
+        'https://example.org/manifest-1'
+      );
+    });
+
+    test('Editing resources', () => {
+      const store = createStore();
+
+      store.dispatch(
+        entityActions.importEntities({
+          entities: {
+            Manifest: {
+              'https://example.org/manifest-1': {
+                ...emptyManifest,
+                id: 'https://example.org/manifest-1',
+                type: 'Manifest',
+                items: [
+                  {
+                    id: 'https://example.org/manifest-1/canvas-1',
+                    type: 'Canvas',
+                  },
+                  {
+                    id: 'https://example.org/manifest-1/canvas-2',
+                    type: 'Canvas',
+                  },
+                ],
+              },
+            },
+            Canvas: {
+              'https://example.org/manifest-1/canvas-1': {
+                ...emptyCanvas,
+                id: 'https://example.org/manifest-1/canvas-1',
+                type: 'Canvas',
+              },
+              'https://example.org/manifest-1/canvas-2': {
+                ...emptyCanvas,
+                id: 'https://example.org/manifest-1/canvas-2',
+                type: 'Canvas',
+              },
+              'https://example.org/manifest-1/canvas-3': {
+                ...emptyCanvas,
+                id: 'https://example.org/manifest-1/canvas-3',
+                type: 'Canvas',
+              },
+            },
+          },
+        })
+      );
+
+      store.dispatch(
+        entityActions.modifyEntityField({
+          id: 'https://example.org/manifest-1',
+          type: 'Manifest',
+          key: 'label',
+          value: { en: ['An example label'] },
+        })
+      );
+
+      expect(store.getState().iiif.entities.Manifest['https://example.org/manifest-1'].label).toEqual({
+        en: ['An example label'],
+      });
+
+      store.dispatch(
+        entityActions.addReference({
+          id: 'https://example.org/manifest-1',
+          type: 'Manifest',
+          key: 'items',
+          reference: {
+            id: 'https://example.org/manifest-1/canvas-3',
+            type: 'Canvas',
+          },
+        })
+      );
+
+      expect(store.getState().iiif.entities.Manifest['https://example.org/manifest-1'].items).toHaveLength(3);
+      expect(store.getState().iiif.entities.Manifest['https://example.org/manifest-1'].items).toMatchInlineSnapshot(`
+        Array [
+          Object {
+            "id": "https://example.org/manifest-1/canvas-1",
+            "type": "Canvas",
+          },
+          Object {
+            "id": "https://example.org/manifest-1/canvas-2",
+            "type": "Canvas",
+          },
+          Object {
+            "id": "https://example.org/manifest-1/canvas-3",
+            "type": "Canvas",
+          },
+        ]
+      `);
+
+      store.dispatch(
+        entityActions.removeReference({
+          id: 'https://example.org/manifest-1',
+          type: 'Manifest',
+          key: 'items',
+          reference: {
+            id: 'https://example.org/manifest-1/canvas-2',
+            type: 'Canvas',
+          },
+        })
+      );
+      expect(store.getState().iiif.entities.Manifest['https://example.org/manifest-1'].items).toHaveLength(2);
+      expect(store.getState().iiif.entities.Manifest['https://example.org/manifest-1'].items).toMatchInlineSnapshot(`
+        Array [
+          Object {
+            "id": "https://example.org/manifest-1/canvas-1",
+            "type": "Canvas",
+          },
+          Object {
+            "id": "https://example.org/manifest-1/canvas-3",
+            "type": "Canvas",
+          },
+        ]
+      `);
+
+      store.dispatch(
+        entityActions.addReference({
+          id: 'https://example.org/manifest-1',
+          type: 'Manifest',
+          key: 'items',
+          reference: {
+            id: 'https://example.org/manifest-1/canvas-2',
+            type: 'Canvas',
+          },
+          index: 1,
+        })
+      );
+
+      expect(store.getState().iiif.entities.Manifest['https://example.org/manifest-1'].items).toHaveLength(3);
+      expect(store.getState().iiif.entities.Manifest['https://example.org/manifest-1'].items).toMatchInlineSnapshot(`
+        Array [
+          Object {
+            "id": "https://example.org/manifest-1/canvas-1",
+            "type": "Canvas",
+          },
+          Object {
+            "id": "https://example.org/manifest-1/canvas-2",
+            "type": "Canvas",
+          },
+          Object {
+            "id": "https://example.org/manifest-1/canvas-3",
+            "type": "Canvas",
+          },
+        ]
+      `);
+
+      // Reordering
+      store.dispatch(
+        entityActions.reorderEntityField({
+          id: 'https://example.org/manifest-1',
+          type: 'Manifest',
+          key: 'items',
+          startIndex: 1,
+          endIndex: 2,
+        })
+      );
+
+      expect(store.getState().iiif.entities.Manifest['https://example.org/manifest-1'].items).toHaveLength(3);
+      expect(store.getState().iiif.entities.Manifest['https://example.org/manifest-1'].items).toMatchInlineSnapshot(`
+        Array [
+          Object {
+            "id": "https://example.org/manifest-1/canvas-1",
+            "type": "Canvas",
+          },
+          Object {
+            "id": "https://example.org/manifest-1/canvas-3",
+            "type": "Canvas",
+          },
+          Object {
+            "id": "https://example.org/manifest-1/canvas-2",
+            "type": "Canvas",
+          },
+        ]
+      `);
+    });
+  });
+});

--- a/pkg-tests/node-load.mjs
+++ b/pkg-tests/node-load.mjs
@@ -1,3 +1,4 @@
 import { Vault } from '@iiif/vault';
+import { entityActions } from '@iiif/vault/actions';
 
-console.log({ Vault });
+console.log({ Vault, entityActions });

--- a/src/actions/entity-actions.ts
+++ b/src/actions/entity-actions.ts
@@ -40,6 +40,7 @@ export const removeReference = createAction(REMOVE_REFERENCE)<{
   type: keyof Entities;
   id: string;
   key: string;
+  index?: number;
   reference: { id: string; type: string } & any;
 }>();
 

--- a/src/actions/entity-actions.ts
+++ b/src/actions/entity-actions.ts
@@ -5,7 +5,13 @@ export const IMPORT_ENTITIES = '@iiif/IMPORT_ENTITIES';
 
 export const MODIFY_ENTITY_FIELD = '@iiif/MODIFY_ENTITY_FIELD';
 
-export const importEntities = createAction(IMPORT_ENTITIES)<{ entities: Entities }>();
+export const REORDER_ENTITY_FIELD = '@iiif/REORDER_ENTITY_FIELD';
+
+export const ADD_REFERENCE = '@iiif/ADD_REFERENCE';
+
+export const REMOVE_REFERENCE = '@iiif/REMOVE_REFERENCE';
+
+export const importEntities = createAction(IMPORT_ENTITIES)<{ entities: Partial<Entities> }>();
 
 export const modifyEntityField = createAction(MODIFY_ENTITY_FIELD)<{
   type: keyof Entities;
@@ -14,6 +20,29 @@ export const modifyEntityField = createAction(MODIFY_ENTITY_FIELD)<{
   value: any;
 }>();
 
-export const entityActions = { importEntities, modifyEntityField };
+export const reorderEntityField = createAction(REORDER_ENTITY_FIELD)<{
+  type: keyof Entities;
+  id: string;
+  key: string;
+  startIndex: number;
+  endIndex: number;
+}>();
+
+export const addReference = createAction(ADD_REFERENCE)<{
+  type: keyof Entities;
+  id: string;
+  key: string;
+  index?: number;
+  reference: { id: string; type: string } & any;
+}>();
+
+export const removeReference = createAction(REMOVE_REFERENCE)<{
+  type: keyof Entities;
+  id: string;
+  key: string;
+  reference: { id: string; type: string } & any;
+}>();
+
+export const entityActions = { importEntities, modifyEntityField, reorderEntityField, addReference, removeReference };
 
 export type EntityActions = ActionType<typeof entityActions>;

--- a/src/store/reducers/batch-reducer.ts
+++ b/src/store/reducers/batch-reducer.ts
@@ -1,4 +1,4 @@
-import { BATCH_ACTIONS, BatchAction } from '../../actions/batch-actions';
+import { BatchAction, BATCH_ACTIONS } from '../../actions/batch-actions';
 import { AllActions } from '../../types';
 import { Reducer } from 'redux';
 

--- a/src/store/reducers/entities-reducer.ts
+++ b/src/store/reducers/entities-reducer.ts
@@ -1,48 +1,120 @@
-import { ActionType } from 'typesafe-actions';
 import { Entities } from '../../types';
 import { getDefaultEntities } from '../../utility';
-import { IMPORT_ENTITIES, importEntities, MODIFY_ENTITY_FIELD, modifyEntityField } from '../../actions';
+import { EntityActions, ADD_REFERENCE, IMPORT_ENTITIES, MODIFY_ENTITY_FIELD, REMOVE_REFERENCE } from '../../actions';
+import { REORDER_ENTITY_FIELD } from '../../actions/entity-actions';
+import { isReferenceList } from '../../utility/is-reference-list';
 
-export const entitiesReducer = (
-  state: Entities = getDefaultEntities(),
-  action: ActionType<typeof importEntities> | ActionType<typeof modifyEntityField>
-) => {
-  if (action.type === MODIFY_ENTITY_FIELD) {
-    // Invalid.
-    if (!state[action.payload.type] || !state[action.payload.type][action.payload.id]) {
-      return state;
-    }
+export const entitiesReducer = (state: Entities = getDefaultEntities(), action: EntityActions) => {
+  switch (action.type) {
+    case MODIFY_ENTITY_FIELD: {
+      // Invalid.
+      if (!state[action.payload.type] || !state[action.payload.type][action.payload.id]) {
+        return state;
+      }
 
-    const entity = state[action.payload.type][action.payload.id];
-    if (typeof entity === 'string') {
-      return state;
-    }
+      const entity = state[action.payload.type][action.payload.id];
+      if (typeof entity === 'string') {
+        return state;
+      }
 
-    return {
-      ...state,
-      [action.payload.type]: {
-        ...state[action.payload.type],
-        [action.payload.id]: {
-          ...entity,
-          [action.payload.key]: action.payload.value,
+      return {
+        ...state,
+        [action.payload.type]: {
+          ...state[action.payload.type],
+          [action.payload.id]: {
+            ...entity,
+            [action.payload.key]: action.payload.value,
+          },
         },
-      },
-    };
-  }
+      };
+    }
+    case REORDER_ENTITY_FIELD: {
+      if (!isReferenceList(state, action.payload.id, action.payload.type, action.payload.key)) {
+        return state;
+      }
 
-  if (action.type === IMPORT_ENTITIES) {
-    const keys = Object.keys(action.payload.entities) as Array<keyof Entities>;
-    const toReturn: Entities = { ...state };
+      const entity: any = state[action.payload.type][action.payload.id];
+      if (typeof entity === 'string') {
+        return state;
+      }
 
-    for (const key of keys) {
-      toReturn[key] = {
-        ...(state[key] || {}),
-        ...(action.payload.entities[key] || {}),
-      } as any;
+      const result = Array.from(entity[action.payload.key]);
+      const [removed] = result.splice(action.payload.startIndex, 1);
+      result.splice(action.payload.endIndex, 0, removed);
+
+      return {
+        ...state,
+        [action.payload.type]: {
+          ...state[action.payload.type],
+          [action.payload.id]: {
+            ...entity,
+            [action.payload.key]: result,
+          },
+        },
+      };
+    }
+    case IMPORT_ENTITIES: {
+      const keys = Object.keys(action.payload.entities) as Array<keyof Entities>;
+      const toReturn: Entities = { ...state };
+
+      for (const key of keys) {
+        toReturn[key] = {
+          ...(state[key] || {}),
+          ...(action.payload.entities[key] || {}),
+        } as any;
+      }
+
+      return toReturn;
     }
 
-    return toReturn;
-  }
+    case ADD_REFERENCE: {
+      if (!isReferenceList(state, action.payload.id, action.payload.type, action.payload.key)) {
+        return state;
+      }
 
-  return state;
+      const entity: any = state[action.payload.type][action.payload.id];
+      const result = Array.from(entity[action.payload.key]);
+      result.splice(action.payload.index || result.length + 1, 0, action.payload.reference);
+
+      return {
+        ...state,
+        [action.payload.type]: {
+          ...state[action.payload.type],
+          [action.payload.id]: {
+            ...entity,
+            [action.payload.key]: result,
+          },
+        },
+      };
+    }
+    case REMOVE_REFERENCE: {
+      if (!isReferenceList(state, action.payload.id, action.payload.type, action.payload.key)) {
+        return state;
+      }
+
+      const entity: any = state[action.payload.type][action.payload.id];
+      const result = Array.from(entity[action.payload.key]);
+      const indexToRemove = result.findIndex((e: any) => e && e.id === action.payload.reference.id);
+
+      if (indexToRemove === -1) {
+        // Nothing to remove.
+        return state;
+      }
+
+      result.splice(indexToRemove, 1);
+
+      return {
+        ...state,
+        [action.payload.type]: {
+          ...state[action.payload.type],
+          [action.payload.id]: {
+            ...entity,
+            [action.payload.key]: result,
+          },
+        },
+      };
+    }
+    default:
+      return state;
+  }
 };

--- a/src/store/reducers/entities-reducer.ts
+++ b/src/store/reducers/entities-reducer.ts
@@ -94,10 +94,15 @@ export const entitiesReducer = (state: Entities = getDefaultEntities(), action: 
 
       const entity: any = state[action.payload.type][action.payload.id];
       const result = Array.from(entity[action.payload.key]);
-      const indexToRemove = result.findIndex((e: any) => e && e.id === action.payload.reference.id);
+      const indexToRemove =
+        action.payload.index || result.findIndex((e: any) => e && e.id === action.payload.reference.id);
 
       if (indexToRemove === -1) {
         // Nothing to remove.
+        return state;
+      }
+      if ((result as any[])[indexToRemove]?.id !== action.payload.reference.id) {
+        // Invalid entity at this position, or the ID does not match.
         return state;
       }
 

--- a/src/store/reducers/mapping-reducer.ts
+++ b/src/store/reducers/mapping-reducer.ts
@@ -1,7 +1,6 @@
-import { ActionType } from 'typesafe-actions';
-import { ADD_MAPPING, ADD_MAPPINGS, mappingActions } from '../../actions';
+import { MappingActions, ADD_MAPPING, ADD_MAPPINGS } from '../../actions';
 
-export const mappingReducer = (state: Record<string, string> = {}, action: ActionType<typeof mappingActions> | any) => {
+export const mappingReducer = (state: Record<string, string> = {}, action: MappingActions) => {
   switch (action.type) {
     case ADD_MAPPING:
       return {

--- a/src/store/reducers/request-reducer.ts
+++ b/src/store/reducers/request-reducer.ts
@@ -1,18 +1,17 @@
 import {
+  RequestActions,
   REQUEST_COMPLETE,
   REQUEST_ERROR,
   REQUEST_MISMATCH,
   REQUEST_OFFLINE_RESOURCE,
   REQUEST_RESOURCE,
-  requestActions,
   RESOURCE_ERROR,
   RESOURCE_LOADING,
   RESOURCE_READY,
 } from '../../actions';
-import { ActionType } from 'typesafe-actions';
 import { RequestState } from '../../types';
 
-export const requestReducer = (state: RequestState = {}, action: ActionType<typeof requestActions>) => {
+export const requestReducer = (state: RequestState = {}, action: RequestActions) => {
   switch (action.type) {
     case REQUEST_RESOURCE:
     case REQUEST_OFFLINE_RESOURCE:

--- a/src/utility/is-reference-list.ts
+++ b/src/utility/is-reference-list.ts
@@ -1,0 +1,10 @@
+import { CompatibleStore } from '@iiif/parser';
+
+export function isReferenceList(state: CompatibleStore['entities'], id: string, type: string, key: string) {
+  return !(
+    !state[type] ||
+    !state[type][id] ||
+    !(state[type][id] as any)[key] ||
+    !Array.isArray((state[type][id] as any)[key])
+  );
+}


### PR DESCRIPTION
* `entityActions.reorderEntityField()` - For reordering items (like canvases in a manifest) without setting the full item set
* `entityActions.addReference()` - For adding new references at an index
* `entityActions.removeReference()` - For removing first instance of a reference OR at specific index (if multiple).


Note: if you're batching these actions - the index _will_ change and you should account for that.