### PR TITLE
Update vault.ts

### DIFF
--- a/src/vault.ts
+++ b/src/vault.ts
@@ -187,6 +187,9 @@ export class Vault {
     }
 
     const state = this.getState();
+        if (!reference) {
+      return [];
+    }
 
     // String IDs.
     if (typeof reference === 'string') {


### PR DESCRIPTION
Catch cases where the reference is undefined, and return an empty array